### PR TITLE
Updated UpdateSeuratForSemla (40)

### DIFF
--- a/R/seurat_to_semla.R
+++ b/R/seurat_to_semla.R
@@ -153,6 +153,8 @@ UpdateSeuratForSemla <- function (
       coordinates <- tibble(barcode = rownames(x), 
              pxl_col_in_fullres = x[, "imagecol", drop = TRUE],
              pxl_row_in_fullres = x[, "imagerow", drop = TRUE],
+             x = x[, "col", drop = TRUE],
+             y = y[, "row", drop = TRUE],
              sampleID = i)
       coordinates_tibble <- bind_rows(coordinates_tibble, coordinates)
     } else if (slice_type == "SlideSeq") {


### PR DESCRIPTION
In response to issue [40](https://github.com/ludvigla/semla/issues/40). Now `UpdateSeuratForSemla` should accept VisiumV2 assays from Seurat. This assay is for VisiumHD but it is also the new assay they are using for overall Visium data. For VisiumV1, the array "x" and "y" coordinates are also taken.