### PR TITLE
UpddateSeuratForSemla() returns a semla object with xy for VisiumV2

### DIFF
--- a/R/seurat_to_semla.R
+++ b/R/seurat_to_semla.R
@@ -193,7 +193,6 @@ UpdateSeuratForSemla <- function (
       coordinates_tibble <- coordinates_tibble |> 
         arrange(y) |> 
         mutate(y = coord_y)
-      # if (verbose) cli_alert_warning("  Missing array coordinates for VisiumV2 sample {i}.")
     } else if (slice_type == "SlideSeq") {
       coordinates <- tibble(barcode = rownames(x), 
                             pxl_col_in_fullres = x[, "x", drop = TRUE],


### PR DESCRIPTION
Added 2 new methods to get xy array coordinates from fullres pixel coordinates for Visium spots. Should work for VisiumHD as well.
Applied those methods for `VisiumV2` assays.